### PR TITLE
added and modified tiered crowdsale tests

### DIFF
--- a/test/MintedCrowdsale.test.js
+++ b/test/MintedCrowdsale.test.js
@@ -14,7 +14,7 @@ const should = require('chai')
 
 contract('LittlePhilCrowdsale as MintedCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 

--- a/test/SetCrowdsaleRate.test.js
+++ b/test/SetCrowdsaleRate.test.js
@@ -36,18 +36,12 @@ contract('Crowdsale', function (accounts) {
             await crowdsale.setRate(newRate, {from: owner}).should.not.be.rejected;
         });
 
-
         it('cannot be changed by non-owner ', async () => {
             const newRate = 3;
             await crowdsale.setRate(newRate, {from: notOwner}).should.be.rejectedWith('revert');
         });
 
         describe('when changed', () => {
-
-            it('should not be rejected', async () => {
-                const newRate = 4;
-                await crowdsale.setRate(newRate, {from: notOwner}).should.be.rejected;
-            });
 
             it('is the new value', async () => {
                 const newRate = 5;

--- a/test/TieredCrowdsale/0_InitialSaleState.test.js
+++ b/test/TieredCrowdsale/0_InitialSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -30,37 +30,40 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Initial SaleState', function () {
 
-        it('should return correct LPC amount', async function () { 
-            const expectedValue = new BigNumber(0);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
-        });
-
-        it('should receive eth in multisig wallet', async function () {
-            const startBal = await web3.eth.getBalance(this.wallet);
-            
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            
-            const endBal = await web3.eth.getBalance(this.wallet);
-            startBal.should.bignumber.equal(endBal);
-        });
-
-        it('should stop minting when cap is reached', async function () {
-            await this.crowdsale.capReached().should.eventually.equal(true);
-        });
-
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-        });
-
-        it('should auto switch between ICO states', async function () { });
-
         it('should return correct integer value for cap values', async function () {
             const cap = await this.crowdsale.getCurrentTierHardcap();
             const expectedCap = new BigNumber(0);
 
             cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should not accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it('should not return LPC', async function () { 
+            const startBal = await this.token.balanceOf(this.account1);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await this.token.balanceOf(this.account1)).should.bignumber.equal(startBal);
+        });
+
+        it('should not receive ETH in multisig wallet', async function () {
+            const startBal = await web3.eth.getBalance(this.wallet);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await web3.eth.getBalance(this.wallet)).should.bignumber.equal(startBal);
+        });
+
+        it('should stop minting when cap (0 LPC) is reached', async function () {
+            await this.crowdsale.capReached().should.eventually.equal(true);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it("should not auto switch between ICO states", async function() {
+            const currentState = await this.crowdsale.state();
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            const updatedState = await this.crowdsale.state();
+            const expectedState = currentState.add(1);
+            expectedState.should.not.bignumber.equal(updatedState);
         });
 
     });

--- a/test/TieredCrowdsale/10_ClosedSaleState.test.js
+++ b/test/TieredCrowdsale/10_ClosedSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -30,37 +30,27 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Closed SaleState', function () {
 
-        it('should return correct LPC amount', async function () {
-            const expectedValue = new BigNumber(0);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
-        });
-
-        it('should receive eth in multisig wallet', async function () {
-            const startBal = await web3.eth.getBalance(this.wallet);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-
-            const endBal = await web3.eth.getBalance(this.wallet);
-            startBal.should.bignumber.equal(endBal);
-        });
-
-        it('should stop minting when cap is reached', async function () {
-            await this.token.mint(this.account1, new BigNumber(10000), { from: this._ }).should.be.rejected;
-        });
-
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-        });
-
-        it("should auto switch between ICO states", async function () {});
-
         it('should return correct integer value for cap values', async function () {
             const cap = await this.crowdsale.getCurrentTierHardcap();
             const expectedCap = new BigNumber(400000000 * 10 ** 18);
 
             cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should not accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it('should not return LPC', async function () {
+            const startBal = await this.token.balanceOf(this.account1);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await this.token.balanceOf(this.account1)).should.bignumber.equal(startBal);
+        });
+
+        it('should not receive ETH in multisig wallet', async function () {
+            const startBal = await web3.eth.getBalance(this.wallet);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await web3.eth.getBalance(this.wallet)).should.bignumber.equal(startBal);
         });
 
     });

--- a/test/TieredCrowdsale/11_MintUnsoldTokens.test.js
+++ b/test/TieredCrowdsale/11_MintUnsoldTokens.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -45,7 +45,14 @@ contract('TieredCrowdsale', (accounts) => {
             const currentTokens = await this.token.balanceOf(await this.crowdsale.airdropWallet());
             const buyValue = ether(1000);
 
-            await this.crowdsale.buyTokens(this.account1, { value: buyValue, from: this.account1 }).should.be.fulfilled;
+            tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+            tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+            tokensPrePurchase = await this.crowdsale.tokensRaised();
+
+            purchaseTarget = tierHardcap.minus(tokensPrePurchase).div(2);
+            purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+            await this.crowdsale.buyTokens(this.account1, { value: purchasePrice, from: this.account1 }).should.be.fulfilled;
+            tokensPostPurchase = await this.crowdsale.tokensRaised();
             await this.crowdsale.setState(10);
 
             const cap = await this.crowdsale.tokenCap();

--- a/test/TieredCrowdsale/1_PrivateSaleState.test.js
+++ b/test/TieredCrowdsale/1_PrivateSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -30,8 +30,20 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Private SaleState', function () {
 
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(400000000 * (10 ** 18));
+
+            cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
+        });
+
         it('should return correct LPC amount', async function () {
-            const expectedValue = expectedTokenAmount;
+            const bonus = await this.crowdsale.getCurrentTierRatePercentage();
+            const expectedValue = expectedTokenAmount.mul(bonus).div(100);
 
             await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
             (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
@@ -46,34 +58,102 @@ contract('TieredCrowdsale', (accounts) => {
             endBal.should.bignumber.equal(startBal.add(value));
         });
 
-        it('should stop minting when cap is reached', async function () {
-            const cappedValue = value.add(ether(400000));
+        describe('when purchase exceeds tier hardcap', function () {
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
-            await this.crowdsale.capReached().should.eventually.equal(true);
-        });
+            const underCapPadding = new BigNumber("500000000000000000000");
+            const weiToExceedCap = new BigNumber(1);
+            let tierBonusRate;
+            let tierHardcap;
+            let tokensPrePurchase;
+            let tokensPostPurchase;
+            let tokensToCap;
+            let purchaseTarget;
+            let purchasePrice;
+            let imprecisePurchasePrice;
+            let purchaseToCap;
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-        });
+            beforeEach(async function () {
+                tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+                tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+                tokensPrePurchase = await this.crowdsale.tokensRaised();
+    
+                purchaseTarget = tierHardcap.minus(tokensPrePurchase).minus(underCapPadding);
+                purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+    
+                imprecisePurchasePrice = new BigNumber(purchasePrice.toPrecision(24));
+                await this.crowdsale.buyTokens(this.account1, { value: imprecisePurchasePrice, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-        it("should auto switch between ICO states", async function() {
-            const cappedValue = ether(400000);
-            const currentState = await this.crowdsale.state();
+                tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                
+                purchaseToCap = new BigNumber(tokensToCap.div(rate).div(tierBonusRate).mul(100).toPrecision(18));
+                purchaseExceedingCap = purchaseToCap.add(weiToExceedCap);
+            });
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
+            // it('should have correct test parameters', async function () {
+            //     console.log("        ===> Tier bonus rate                      :                                 " + tierBonusRate);
+            //     console.log("        ===> Tier hardcap                         : " + tierHardcap.toFormat(0));
+            //     console.log("        ===> LPC raised before initial purcahse   :                                   " + tokensPrePurchase.toFormat(0));
+            //     console.log("        ===> LPC purchase target                  : " + purchaseTarget.toFormat(0));
+            //     console.log("        ===> Wei purchase price                   :     " + purchasePrice.toFormat(0));
+            //     console.log("        ===> Imprecise purchase price             :     " + imprecisePurchasePrice.toFormat(0));
+            //     console.log("        ===> LPC raised after initial purcahse:   : " + tokensPostPurchase.toFormat(0));
+            //     console.log("        ===> LPC remaing before reaching hardcap  :         " + tokensToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price for remaining LPC :             " + purchaseToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price to exceed hardcap :             " + purchaseExceedingCap.toFormat(0));
+            // });
 
-            const updatedState = await this.crowdsale.state();
-            const expectedState = currentState.add(1);
+            it('should emit a CapOverflow event', async function () {
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                should.exist(event);
+            });
 
-            expectedState.should.bignumber.equal(updatedState);
-        });
+            it('expected LPC should be less than LPC received', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                const tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(400000000 * (10 ** 18));
+                const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
+                const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
+                actualTokens.should.be.bignumber.lessThan(expectedTokens);
+            });
 
-            cap.should.bignumber.equal(expectedCap);
+            it('should not have any tokens remaining for tier', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                const tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                tokensToCap.should.be.bignumber.equal(new BigNumber(0));
+            });
+
+            it('should emit correct CapOverflow event values', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                event.args.sender.should.be.equal(this.account1);
+                event.args.weiAmount.should.be.bignumber.equal(purchaseExceedingCap);
+                event.args.receivedTokens.should.be.bignumber.equal(tokensPostPurchase.minus(tokensPrePurchase));
+                // check difference between actual timestamp and event timestamp is < 5 minutes
+                // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
+                // const dateNow = new BigNumber(Date.now()).div(1000);
+                // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
+            });
+
+            it('should stop minting when cap is reached', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                (await this.crowdsale.capReached()).should.equal(true);
+            });
+    
+            it("should auto switch between ICO states", async function() {
+                const currentState = await this.crowdsale.state();
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const updatedState = await this.crowdsale.state();
+                const expectedState = currentState.add(1);
+                expectedState.should.bignumber.equal(updatedState);
+            });
+    
         });
 
     });

--- a/test/TieredCrowdsale/2_FinalisedPrivateSaleState.test.js
+++ b/test/TieredCrowdsale/2_FinalisedPrivateSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -31,37 +31,40 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Finalised Private SaleState', function () {
 
-        it('should return correct LPC amount', async function () {
-            const expectedValue = new BigNumber(0);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
-        });
-
-        it('should receive eth in multisig wallet', async function () {
-            const startBal = await web3.eth.getBalance(this.wallet);
-            
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            
-            const endBal = await web3.eth.getBalance(this.wallet);
-            startBal.should.bignumber.equal(endBal);
-        });
-
-        it('should stop minting when cap is reached', async function () {
-            await this.crowdsale.capReached().should.eventually.equal(true);
-        });
-
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-        });
-
-        it('should auto switch between ICO states', async function () {});
-
         it('should return correct integer value for cap values', async function () {
             const cap = await this.crowdsale.getCurrentTierHardcap();
             const expectedCap = new BigNumber(0);
 
             cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should not accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it('should not return LPC', async function () {
+            const startBal = await this.token.balanceOf(this.account1);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await this.token.balanceOf(this.account1)).should.bignumber.equal(startBal);
+        });
+
+        it('should not receive ETH in multisig wallet', async function () {
+            const startBal = await web3.eth.getBalance(this.wallet);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await web3.eth.getBalance(this.wallet)).should.bignumber.equal(startBal);
+        });
+
+        it('should stop minting when cap (0 LPC) is reached', async function () {
+            await this.crowdsale.capReached().should.eventually.equal(true);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it("should not auto switch between ICO states", async function() {
+            const currentState = await this.crowdsale.state();
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            const updatedState = await this.crowdsale.state();
+            const expectedState = currentState.add(1);
+            expectedState.should.not.bignumber.equal(updatedState);
         });
 
     });

--- a/test/TieredCrowdsale/3_PreSaleState.test.js
+++ b/test/TieredCrowdsale/3_PreSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
     const expectedTokenAmount = value.mul(rate);
 
     beforeEach(async function () {
@@ -105,15 +105,12 @@ contract('TieredCrowdsale', (accounts) => {
             // });
             
             it('should emit a CapOverflow event', async function () {
-
                 const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 const event = logs.find(e => e.event == 'CapOverflow');
                 should.exist(event);
-
             });
 
             it('expected LPC should be less than LPC received', async function () {
-
                 const tokensPrePurchase = await this.crowdsale.tokensRaised();
                 const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 const event = logs.find(e => e.event == 'CapOverflow');
@@ -122,20 +119,16 @@ contract('TieredCrowdsale', (accounts) => {
                 const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
                 const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
                 actualTokens.should.be.bignumber.lessThan(expectedTokens);
-
             });
 
             it('should not have any tokens remaining for tier', async function () {
-
                 await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 tokensPostPurchase = await this.crowdsale.tokensRaised();
                 const tokensToCap = tierHardcap.minus(tokensPostPurchase);
                 tokensToCap.should.be.bignumber.equal(new BigNumber(0));
-
             });
 
             it('should emit correct CapOverflow event values', async function () {
-
                 const tokensPrePurchase = await this.crowdsale.tokensRaised();
                 const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 const event = logs.find(e => e.event == 'CapOverflow');
@@ -147,23 +140,19 @@ contract('TieredCrowdsale', (accounts) => {
                 // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
                 // const dateNow = new BigNumber(Date.now()).div(1000);
                 // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
-
             });
 
             it('should stop minting', async function () {
-
                 await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 (await this.crowdsale.capReached()).should.equal(true);
             });
 
             it('should auto-switch to next ICO state', async function () {
-
                 const currentState = await this.crowdsale.state();
                 await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
                 const updatedState = await this.crowdsale.state();
                 const expectedState = currentState.add(1);
                 expectedState.should.bignumber.equal(updatedState);
-
             });
 
         });

--- a/test/TieredCrowdsale/4_FinalisedPreSaleState.test.js
+++ b/test/TieredCrowdsale/4_FinalisedPreSaleState.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -30,37 +30,40 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Finalised Presale SaleState', function () {
 
-        it('should return correct LPC amount', async function () {
-            const expectedValue = new BigNumber(0);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
-        });
-
-        it('should receive eth in multisig wallet', async function () {
-            const startBal = await web3.eth.getBalance(this.wallet);
-            
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            
-            const endBal = await web3.eth.getBalance(this.wallet);
-            startBal.should.bignumber.equal(endBal);
-        });
-
-        it('should stop minting when cap is reached', async function () {
-            await this.crowdsale.capReached().should.eventually.equal(true);
-        });
-
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-        });
-
-        it("should auto switch between ICO states", async function() {});
-
         it('should return correct integer value for cap values', async function () {
             const cap = await this.crowdsale.getCurrentTierHardcap();
             const expectedCap = new BigNumber(0);
 
             cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it('should not return LPC', async function () {
+            const startBal = await this.token.balanceOf(this.account1);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await this.token.balanceOf(this.account1)).should.bignumber.equal(startBal);
+        });
+
+        it('should not receive ETH in multisig wallet', async function () {
+            const startBal = await web3.eth.getBalance(this.wallet);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await web3.eth.getBalance(this.wallet)).should.bignumber.equal(startBal);
+        });
+
+        it('should stop minting when cap (0 LPC) is reached', async function () {
+            await this.crowdsale.capReached().should.eventually.equal(true);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it("should not auto switch between ICO states", async function() {
+            const currentState = await this.crowdsale.state();
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            const updatedState = await this.crowdsale.state();
+            const expectedState = currentState.add(1);
+            expectedState.should.not.bignumber.equal(updatedState);
         });
 
     });

--- a/test/TieredCrowdsale/5_PublicSaleTier1.test.js
+++ b/test/TieredCrowdsale/5_PublicSaleTier1.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
     const expectedTokenAmount = value.mul(rate);
 
     beforeEach(async function () {
@@ -28,6 +28,17 @@ contract('TieredCrowdsale', (accounts) => {
     });
 
     describe('Public Tier 1 SaleState', function () {
+
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(265000000 * (10 ** 18));
+
+            cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
+        });
 
         it('should return correct LPC amount', async function () {
             const bonus = await this.crowdsale.getCurrentTierRatePercentage();
@@ -46,26 +57,100 @@ contract('TieredCrowdsale', (accounts) => {
             endBal.should.bignumber.equal(startBal.add(value));
         });
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-        });
+        describe('when purchase exceeds tier hardcap', function () {
 
-        it("should auto switch between ICO states", async function () {
-            const cappedValue = value.add(ether(400000));
-            const currentState = await this.crowdsale.state();
+            const underCapPadding = new BigNumber("500000000000000000000");
+            const weiToExceedCap = new BigNumber(1);
+            let tierBonusRate;
+            let tierHardcap;
+            let tokensPrePurchase;
+            let tokensPostPurchase;
+            let tokensToCap;
+            let purchaseTarget;
+            let purchasePrice;
+            let imprecisePurchasePrice;
+            let purchaseToCap;
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
+            beforeEach(async function () {
 
-            const updatedState = await this.crowdsale.state();
-            const expectedState = currentState.add(1);
+                tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+                tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+                tokensPrePurchase = await this.crowdsale.tokensRaised();
+    
+                purchaseTarget = tierHardcap.minus(tokensPrePurchase).minus(underCapPadding);
+                purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+    
+                imprecisePurchasePrice = new BigNumber(purchasePrice.toPrecision(24));
+                await this.crowdsale.buyTokens(this.account1, { value: imprecisePurchasePrice, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-            expectedState.should.bignumber.equal(updatedState);});
+                tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                
+                purchaseToCap = new BigNumber(tokensToCap.div(rate).div(tierBonusRate).mul(100).toPrecision(18));
+                purchaseExceedingCap = purchaseToCap.add(weiToExceedCap);
 
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(265000000 * (10 ** 18));
+            });
 
-            cap.should.bignumber.equal(expectedCap);
+            // it('should have correct test parameters', async function () {
+            //     console.log("        ===> Tier bonus rate                      :                                 " + tierBonusRate);
+            //     console.log("        ===> Tier hardcap                         : " + tierHardcap.toFormat(0));
+            //     console.log("        ===> LPC raised before initial purcahse   :                                   " + tokensPrePurchase.toFormat(0));
+            //     console.log("        ===> LPC purchase target                  : " + purchaseTarget.toFormat(0));
+            //     console.log("        ===> Wei purchase price                   :     " + purchasePrice.toFormat(0));
+            //     console.log("        ===> Imprecise purchase price             :     " + imprecisePurchasePrice.toFormat(0));
+            //     console.log("        ===> LPC raised after initial purcahse:   : " + tokensPostPurchase.toFormat(0));
+            //     console.log("        ===> LPC remaing before reaching hardcap  :         " + tokensToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price for remaining LPC :             " + purchaseToCap.toFormat(0));
+            //     console.log("        ===> Expected LPC purchase                :         " + (purchaseToCap.mul(rate).mul(tierBonusRate).div(100)).toFormat(0));
+            //     console.log("        ===> Wei purchase price to exceed hardcap :             " + purchaseExceedingCap.toFormat(0));
+            // });
+            
+            it('should emit a CapOverflow event', async function () {
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                should.exist(event);
+            });
+
+            it('expected LPC should be less than LPC received', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                const tokensPostPurchase = await this.crowdsale.tokensRaised();
+
+                const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
+                const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
+                actualTokens.should.be.bignumber.lessThan(expectedTokens);
+            });
+
+            it('should not have any tokens remaining for tier', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                const tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                tokensToCap.should.be.bignumber.equal(new BigNumber(0));
+            });
+
+            it('should emit correct CapOverflow event values', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                event.args.sender.should.be.equal(this.account1);
+                event.args.weiAmount.should.be.bignumber.equal(purchaseExceedingCap);
+                event.args.receivedTokens.should.be.bignumber.equal(tokensPostPurchase.minus(tokensPrePurchase));
+                // check difference between actual timestamp and event timestamp is < 5 minutes
+                // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
+                // const dateNow = new BigNumber(Date.now()).div(1000);
+                // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
+            });
+
+            it('should auto-switch to next ICO state', async function () {
+                const currentState = await this.crowdsale.state();
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const updatedState = await this.crowdsale.state();
+                const expectedState = currentState.add(1);
+                expectedState.should.bignumber.equal(updatedState);
+            });
+
         });
 
     });

--- a/test/TieredCrowdsale/6_PublicSaleTier2.test.js
+++ b/test/TieredCrowdsale/6_PublicSaleTier2.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
     const expectedTokenAmount = value.mul(rate);
 
     beforeEach(async function () {
@@ -29,6 +29,17 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Public Tier 2 SaleState', function () {
 
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(330000000 * 10 ** 18);
+
+            cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
+        });
+
         it('should return correct LPC amount', async function () {
             const bonus = await this.crowdsale.getCurrentTierRatePercentage();
             const expectedValue = expectedTokenAmount.mul(bonus).div(100);
@@ -41,34 +52,105 @@ contract('TieredCrowdsale', (accounts) => {
             const startBal = await web3.eth.getBalance(this.wallet);
 
             await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-
+            
             const endBal = await web3.eth.getBalance(this.wallet);
             endBal.should.bignumber.equal(startBal.add(value));
         });
 
-        it('should stop minting when cap is reached', async function () {});
+        describe('when purchase exceeds tier hardcap', function () {
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-        });
+            const underCapPadding = new BigNumber("500000000000000000000");
+            const weiToExceedCap = new BigNumber(1);
+            let tierBonusRate;
+            let tierHardcap;
+            let tokensPrePurchase;
+            let tokensPostPurchase;
+            let tokensToCap;
+            let purchaseTarget;
+            let purchasePrice;
+            let imprecisePurchasePrice;
+            let purchaseToCap;
 
-        it("should auto switch between ICO states", async function () {
-            const cappedValue = value.add(ether(400000));
-            const currentState = await this.crowdsale.state();
+            beforeEach(async function () {
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
+                tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+                tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+                tokensPrePurchase = await this.crowdsale.tokensRaised();
+    
+                purchaseTarget = tierHardcap.minus(tokensPrePurchase).minus(underCapPadding);
+                purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+    
+                imprecisePurchasePrice = new BigNumber(purchasePrice.toPrecision(24));
+                await this.crowdsale.buyTokens(this.account1, { value: imprecisePurchasePrice, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-            const updatedState = await this.crowdsale.state();
-            const expectedState = currentState.add(1);
+                tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                
+                purchaseToCap = new BigNumber(tokensToCap.div(rate).div(tierBonusRate).mul(100).toPrecision(18));
+                purchaseExceedingCap = purchaseToCap.add(weiToExceedCap);
 
-            expectedState.should.bignumber.equal(updatedState);
-        });
+            });
 
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(330000000 * 10 ** 18);
+            // it('should have correct test parameters', async function () {
+            //     console.log("        ===> Tier bonus rate                      :                                 " + tierBonusRate);
+            //     console.log("        ===> Tier hardcap                         : " + tierHardcap.toFormat(0));
+            //     console.log("        ===> LPC raised before initial purcahse   :                                   " + tokensPrePurchase.toFormat(0));
+            //     console.log("        ===> LPC purchase target                  : " + purchaseTarget.toFormat(0));
+            //     console.log("        ===> Wei purchase price                   :     " + purchasePrice.toFormat(0));
+            //     console.log("        ===> Imprecise purchase price             :     " + imprecisePurchasePrice.toFormat(0));
+            //     console.log("        ===> LPC raised after initial purcahse:   : " + tokensPostPurchase.toFormat(0));
+            //     console.log("        ===> LPC remaing before reaching hardcap  :         " + tokensToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price for remaining LPC :             " + purchaseToCap.toFormat(0));
+            //     console.log("        ===> Expected LPC purchase                :         " + (purchaseToCap.mul(rate).mul(tierBonusRate).div(100)).toFormat(0));
+            //     console.log("        ===> Wei purchase price to exceed hardcap :             " + purchaseExceedingCap.toFormat(0));
+            // });
+            
+            it('should emit a CapOverflow event', async function () {
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                should.exist(event);
+            });
 
-            cap.should.bignumber.equal(expectedCap);
+            it('expected LPC should be less than LPC received', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                const tokensPostPurchase = await this.crowdsale.tokensRaised();
+
+                const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
+                const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
+                actualTokens.should.be.bignumber.lessThan(expectedTokens);
+            });
+
+            it('should not have any tokens remaining for tier', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                const tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                tokensToCap.should.be.bignumber.equal(new BigNumber(0));
+            });
+
+            it('should emit correct CapOverflow event values', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                event.args.sender.should.be.equal(this.account1);
+                event.args.weiAmount.should.be.bignumber.equal(purchaseExceedingCap);
+                event.args.receivedTokens.should.be.bignumber.equal(tokensPostPurchase.minus(tokensPrePurchase));
+                // check difference between actual timestamp and event timestamp is < 5 minutes
+                // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
+                // const dateNow = new BigNumber(Date.now()).div(1000);
+                // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
+            });
+
+            it('should auto-switch to next ICO state', async function () {
+                const currentState = await this.crowdsale.state();
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const updatedState = await this.crowdsale.state();
+                const expectedState = currentState.add(1);
+                expectedState.should.bignumber.equal(updatedState);
+            });
+
         });
 
     });

--- a/test/TieredCrowdsale/7_PublicSaleTier3.test.js
+++ b/test/TieredCrowdsale/7_PublicSaleTier3.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
     const expectedTokenAmount = value.mul(rate);
 
     beforeEach(async function () {
@@ -29,6 +29,18 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Public Tier 3 SaleState', function () {
 
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(375000000 * 10 ** 18);
+
+            cap.should.bignumber.equal(expectedCap);
+        });
+
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
+        });
+
         it('should return correct LPC amount', async function () {
             const bonus = await this.crowdsale.getCurrentTierRatePercentage();
             const expectedValue = expectedTokenAmount.mul(bonus).div(100);
@@ -41,32 +53,105 @@ contract('TieredCrowdsale', (accounts) => {
             const startBal = await web3.eth.getBalance(this.wallet);
 
             await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-
+            
             const endBal = await web3.eth.getBalance(this.wallet);
             endBal.should.bignumber.equal(startBal.add(value));
         });
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-        });
+        describe('when purchase exceeds tier hardcap', function () {
 
-        it("should auto switch between ICO states", async function () {
-            const cappedValue = value.add(ether(400000));
-            const currentState = await this.crowdsale.state();
+            const underCapPadding = new BigNumber("500000000000000000000");
+            const weiToExceedCap = new BigNumber(1);
+            let tierBonusRate;
+            let tierHardcap;
+            let tokensPrePurchase;
+            let tokensPostPurchase;
+            let tokensToCap;
+            let purchaseTarget;
+            let purchasePrice;
+            let imprecisePurchasePrice;
+            let purchaseToCap;
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
+            beforeEach(async function () {
 
-            const updatedState = await this.crowdsale.state();
-            const expectedState = currentState.add(1);
+                tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+                tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+                tokensPrePurchase = await this.crowdsale.tokensRaised();
+    
+                purchaseTarget = tierHardcap.minus(tokensPrePurchase).minus(underCapPadding);
+                purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+    
+                imprecisePurchasePrice = new BigNumber(purchasePrice.toPrecision(24));
+                await this.crowdsale.buyTokens(this.account1, { value: imprecisePurchasePrice, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-            expectedState.should.bignumber.equal(updatedState);
-        });
+                tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                
+                purchaseToCap = new BigNumber(tokensToCap.div(rate).div(tierBonusRate).mul(100).toPrecision(18));
+                purchaseExceedingCap = purchaseToCap.add(weiToExceedCap);
 
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(375000000 * 10 ** 18);
+            });
 
-            cap.should.bignumber.equal(expectedCap);
+            // it('should have correct test parameters', async function () {
+            //     console.log("        ===> Tier bonus rate                      :                                 " + tierBonusRate);
+            //     console.log("        ===> Tier hardcap                         : " + tierHardcap.toFormat(0));
+            //     console.log("        ===> LPC raised before initial purcahse   :                                   " + tokensPrePurchase.toFormat(0));
+            //     console.log("        ===> LPC purchase target                  : " + purchaseTarget.toFormat(0));
+            //     console.log("        ===> Wei purchase price                   :     " + purchasePrice.toFormat(0));
+            //     console.log("        ===> Imprecise purchase price             :     " + imprecisePurchasePrice.toFormat(0));
+            //     console.log("        ===> LPC raised after initial purcahse:   : " + tokensPostPurchase.toFormat(0));
+            //     console.log("        ===> LPC remaing before reaching hardcap  :         " + tokensToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price for remaining LPC :             " + purchaseToCap.toFormat(0));
+            //     console.log("        ===> Expected LPC purchase                :         " + (purchaseToCap.mul(rate).mul(tierBonusRate).div(100)).toFormat(0));
+            //     console.log("        ===> Wei purchase price to exceed hardcap :             " + purchaseExceedingCap.toFormat(0));
+            // });
+            
+            it('should emit a CapOverflow event', async function () {
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                should.exist(event);
+            });
+
+            it('expected LPC should be less than LPC received', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                const tokensPostPurchase = await this.crowdsale.tokensRaised();
+
+                const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
+                const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
+                actualTokens.should.be.bignumber.lessThan(expectedTokens);
+            });
+
+            it('should not have any tokens remaining for tier', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                const tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                tokensToCap.should.be.bignumber.equal(new BigNumber(0));
+            });
+
+            it('should emit correct CapOverflow event values', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                event.args.sender.should.be.equal(this.account1);
+                event.args.weiAmount.should.be.bignumber.equal(purchaseExceedingCap);
+                event.args.receivedTokens.should.be.bignumber.equal(tokensPostPurchase.minus(tokensPrePurchase));
+                // check difference between actual timestamp and event timestamp is < 5 minutes
+                // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
+                // const dateNow = new BigNumber(Date.now()).div(1000);
+                // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
+            });
+
+            it('should auto-switch to next ICO state', async function () {
+                const currentState = await this.crowdsale.state();
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const updatedState = await this.crowdsale.state();
+                const expectedState = currentState.add(1);
+                expectedState.should.bignumber.equal(updatedState);
+            });
+
         });
 
     });

--- a/test/TieredCrowdsale/8_PublicSaleTier4.test.js
+++ b/test/TieredCrowdsale/8_PublicSaleTier4.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
     const expectedTokenAmount = value.mul(rate);
 
     beforeEach(async function () {
@@ -29,6 +29,17 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Public Tier 4 SaleState', function () {
 
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(400000000 * 10 ** 18);
+
+            cap.should.bignumber.equal(expectedCap);
+        });
+
+        it('should accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
+        });
+
         it('should return correct LPC amount', async function () {
             const bonus = await this.crowdsale.getCurrentTierRatePercentage();
             const expectedValue = expectedTokenAmount.mul(bonus).div(100);
@@ -41,39 +52,105 @@ contract('TieredCrowdsale', (accounts) => {
             const startBal = await web3.eth.getBalance(this.wallet);
 
             await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-
+            
             const endBal = await web3.eth.getBalance(this.wallet);
             endBal.should.bignumber.equal(startBal.add(value));
         });
 
-        it('should stop minting when cap is reached', async function () {
-            const cappedValue = value.add(ether(400000));
+        describe('when purchase exceeds tier hardcap', function () {
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
-            await this.crowdsale.capReached().should.eventually.equal(true);
-        });
+            const underCapPadding = new BigNumber("500000000000000000000");
+            const weiToExceedCap = new BigNumber(1);
+            let tierBonusRate;
+            let tierHardcap;
+            let tokensPrePurchase;
+            let tokensPostPurchase;
+            let tokensToCap;
+            let purchaseTarget;
+            let purchasePrice;
+            let imprecisePurchasePrice;
+            let purchaseToCap;
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.fulfilled;
-        });
+            beforeEach(async function () {
 
-        it("should auto switch between ICO states", async function () {
-            const cappedValue = value.add(ether(400000));
-            const currentState = await this.crowdsale.state();
+                tierBonusRate = await this.crowdsale.getCurrentTierRatePercentage();
+                tierHardcap = await this.crowdsale.getCurrentTierHardcap();
+                tokensPrePurchase = await this.crowdsale.tokensRaised();
+    
+                purchaseTarget = tierHardcap.minus(tokensPrePurchase).minus(underCapPadding);
+                purchasePrice = purchaseTarget.div(rate).div(tierBonusRate).mul(100);
+    
+                imprecisePurchasePrice = new BigNumber(purchasePrice.toPrecision(24));
+                await this.crowdsale.buyTokens(this.account1, { value: imprecisePurchasePrice, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-            await this.crowdsale.buyTokens(this.account1, { value: cappedValue, from: this.account1 }).should.be.fulfilled;
+                tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                
+                purchaseToCap = new BigNumber(tokensToCap.div(rate).div(tierBonusRate).mul(100).toPrecision(18));
+                purchaseExceedingCap = purchaseToCap.add(weiToExceedCap);
 
-            const updatedState = await this.crowdsale.state();
-            const expectedState = currentState.add(1);
+            });
 
-            expectedState.should.bignumber.equal(updatedState);
-        });
+            // it('should have correct test parameters', async function () {
+            //     console.log("        ===> Tier bonus rate                      :                                 " + tierBonusRate);
+            //     console.log("        ===> Tier hardcap                         : " + tierHardcap.toFormat(0));
+            //     console.log("        ===> LPC raised before initial purcahse   :                                   " + tokensPrePurchase.toFormat(0));
+            //     console.log("        ===> LPC purchase target                  : " + purchaseTarget.toFormat(0));
+            //     console.log("        ===> Wei purchase price                   :     " + purchasePrice.toFormat(0));
+            //     console.log("        ===> Imprecise purchase price             :     " + imprecisePurchasePrice.toFormat(0));
+            //     console.log("        ===> LPC raised after initial purcahse:   : " + tokensPostPurchase.toFormat(0));
+            //     console.log("        ===> LPC remaing before reaching hardcap  :         " + tokensToCap.toFormat(0));
+            //     console.log("        ===> Wei purchase price for remaining LPC :             " + purchaseToCap.toFormat(0));
+            //     console.log("        ===> Expected LPC purchase                :         " + (purchaseToCap.mul(rate).mul(tierBonusRate).div(100)).toFormat(0));
+            //     console.log("        ===> Wei purchase price to exceed hardcap :             " + purchaseExceedingCap.toFormat(0));
+            // });
+            
+            it('should emit a CapOverflow event', async function () {
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                should.exist(event);
+            });
 
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(400000000 * 10 ** 18);
+            it('expected LPC should be less than LPC received', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                const tokensPostPurchase = await this.crowdsale.tokensRaised();
 
-            cap.should.bignumber.equal(expectedCap);
+                const expectedTokens = (purchaseExceedingCap).mul(rate).mul(tierBonusRate).div(100);
+                const actualTokens = tokensPostPurchase.minus(tokensPrePurchase);
+                actualTokens.should.be.bignumber.lessThan(expectedTokens);
+            });
+
+            it('should not have any tokens remaining for tier', async function () {
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                const tokensToCap = tierHardcap.minus(tokensPostPurchase);
+                tokensToCap.should.be.bignumber.equal(new BigNumber(0));
+            });
+
+            it('should emit correct CapOverflow event values', async function () {
+                const tokensPrePurchase = await this.crowdsale.tokensRaised();
+                const {logs} = await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const event = logs.find(e => e.event == 'CapOverflow');
+                tokensPostPurchase = await this.crowdsale.tokensRaised();
+                event.args.sender.should.be.equal(this.account1);
+                event.args.weiAmount.should.be.bignumber.equal(purchaseExceedingCap);
+                event.args.receivedTokens.should.be.bignumber.equal(tokensPostPurchase.minus(tokensPrePurchase));
+                // check difference between actual timestamp and event timestamp is < 5 minutes
+                // Note: this doesn't seem to work when tested on a remote test server.  Commented out.
+                // const dateNow = new BigNumber(Date.now()).div(1000);
+                // (event.args.date.minus(dateNow)).abs().should.be.bignumber.lessThan(300);
+            });
+
+            it('should auto-switch to next ICO state', async function () {
+                const currentState = await this.crowdsale.state();
+                await this.crowdsale.buyTokens(this.account1, { value: purchaseExceedingCap, from: this.account1 });
+                const updatedState = await this.crowdsale.state();
+                const expectedState = currentState.add(1);
+                expectedState.should.bignumber.equal(updatedState);
+            });
+
         });
 
     });

--- a/test/TieredCrowdsale/9_FinalisedPublicSale.test.js
+++ b/test/TieredCrowdsale/9_FinalisedPublicSale.test.js
@@ -13,7 +13,7 @@ const should = require('chai')
 
 contract('TieredCrowdsale', (accounts) => {
     const rate = new BigNumber(1000);
-    const value = ether(12);
+    const value = ether(0.3);
 
     const expectedTokenAmount = value.mul(rate);
 
@@ -30,46 +30,39 @@ contract('TieredCrowdsale', (accounts) => {
 
     describe('Finalised Presale SaleState', function () {
 
-        it('should return correct LPC amount', async function () {
-            const expectedValue = new BigNumber(0);
+        it('should return correct integer value for cap values', async function () {
+            const cap = await this.crowdsale.getCurrentTierHardcap();
+            const expectedCap = new BigNumber(0);
 
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-            (await this.token.balanceOf(this.account1)).should.bignumber.equal(expectedValue);
+            cap.should.bignumber.equal(expectedCap);
         });
 
-        it('should receive eth in multisig wallet', async function () {
+        it('should not accept transactions', async function () {
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+        });
+
+        it('should not return LPC', async function () {
+            const startBal = await this.token.balanceOf(this.account1);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await this.token.balanceOf(this.account1)).should.bignumber.equal(startBal);
+        });
+
+        it('should not receive ETH in multisig wallet', async function () {
             const startBal = await web3.eth.getBalance(this.wallet);
-
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-
-            const endBal = await web3.eth.getBalance(this.wallet);
-            startBal.should.bignumber.equal(endBal);
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
+            (await web3.eth.getBalance(this.wallet)).should.bignumber.equal(startBal);
         });
 
         it('should stop minting when cap is reached', async function () {
             await this.crowdsale.capReached().should.eventually.equal(true);
         });
 
-        it('should accept transactions based on state', async function () {
-            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejected;
-        });
-
-        it("should auto switch between ICO states", async function () {
+        it("should not auto switch between ICO states", async function() {
             const currentState = await this.crowdsale.state();
-
-            await this.crowdsale.setState(10);
-
+            await this.crowdsale.buyTokens(this.account1, { value: value, from: this.account1 }).should.be.rejectedWith('revert');
             const updatedState = await this.crowdsale.state();
             const expectedState = currentState.add(1);
-
-            expectedState.should.bignumber.equal(updatedState);
-        });
-
-        it('should return correct integer value for cap values', async function () {
-            const cap = await this.crowdsale.getCurrentTierHardcap();
-            const expectedCap = new BigNumber(0);
-
-            cap.should.bignumber.equal(expectedCap);
+            expectedState.should.not.bignumber.equal(updatedState);
         });
 
     });

--- a/test/TokenCapped.test.js
+++ b/test/TokenCapped.test.js
@@ -10,7 +10,7 @@ const should = require('chai')
     .should();
 
 contract('CappedToken', (accounts) => {
-    const value = ether(12);
+    const value = ether(0.3);
     const owner = accounts[0];
 
     beforeEach(async function () {


### PR DESCRIPTION
- changed to using 0.3 ETH to avoid chewing up so much during testing.
- modified some test titles (pretty insignificant - mostly just for readability).
- added tests to validate and verify events emitted when some caps reached.
- calculated a value to reach and exceed each hardcap rather than just throw a bunch of ETH at it.

Note: at this point, all tests pass.